### PR TITLE
new GA keys for beta.nationalmap and pacific map

### DIFF
--- a/nationalmap/map-config/prod.json
+++ b/nationalmap/map-config/prod.json
@@ -43,6 +43,7 @@
         },
         "experimentalFeatures": true,
         "feedbackUrl": "feedback",
+        "googleAnalyticsKey": "UA-63280156-20",
         "helpContent": [
           {
             "icon": "video",

--- a/pacificmap/map-config/prod.json
+++ b/pacificmap/map-config/prod.json
@@ -70,6 +70,7 @@
         },
         "experimentalFeatures": true,
         "feedbackUrl": "feedback",
+        "googleAnalyticsKey": "UA-63280156-19",
         "helpContent": [
           {
             "icon": "video",


### PR DESCRIPTION
Note: keys have also been updated in nationalmap standalone repo (master) and also updated in the public API keys in the handbook